### PR TITLE
Fix undefined method 'assets' for Rails::Application::Configuration

### DIFF
--- a/ffcrm_awesome.gemspec
+++ b/ffcrm_awesome.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["spec/**/*"]
 
   s.add_dependency "rails"
+  s.add_dependency "sprockets-rails"
   # s.add_dependency "jquery-rails"
 
   s.add_development_dependency "pg"

--- a/lib/ffcrm_awesome.rb
+++ b/lib/ffcrm_awesome.rb
@@ -1,3 +1,4 @@
+require "sprockets/railtie"
 require "ffcrm_awesome/engine"
 
 module FfcrmAwesome

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'rubygems'
 require 'bundler'
+require 'sprockets/railtie'
 require 'rails/all'
 
 Bundler.require :default, :development


### PR DESCRIPTION
Fixed the `NoMethodError: undefined method 'assets' for an instance of Rails::Application::Configuration` by explicitly including `sprockets-rails` and requiring its railtie. This is necessary for Rails 7+ compatibility where Sprockets is no longer a default part of the framework.

---
*PR created automatically by Jules for task [15108873961630223637](https://jules.google.com/task/15108873961630223637) started by @CloCkWeRX*